### PR TITLE
next release v2.4.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,15 +50,8 @@ jobs:
       with:
         fetch-depth: 0
     - name: Run setup-python
-      run: setup-python -p${{ matrix.python }}
+      run: setup-python -p${{ matrix.python }} cupy
     - run: pip install -U -e .[dev]
-    - name: pip install cupy
-      run: |
-        CUVER=$(ls /usr/local/cuda-* -d | sed -r 's/\/usr\/local\/cuda-([0-9]+)\.([0-9]+)/\1\2/' | sort -nr | head -n1)
-        echo CUDA Tookit: $CUVER
-        [[ $CUVER -gt 111 ]] && CUVER=111
-        echo Installing: cupy-cuda$CUVER
-        pip install cupy-cuda$CUVER
     - run: pytest
     - run: codecov
     - name: Post Run setup-python

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,6 +52,13 @@ jobs:
     - name: Run setup-python
       run: setup-python -p${{ matrix.python }}
     - run: pip install -U -e .[dev]
+    - name: pip install cupy
+      run: |
+        CUVER=$(ls /usr/local/cuda-* -d | sed -r 's/\/usr\/local\/cuda-([0-9]+)\.([0-9]+)/\1\2/' | sort -nr | head -n1)
+        echo CUDA Tookit: $CUVER
+        [[ $CUVER -gt 111 ]] && CUVER=111
+        echo Installing: cupy-cuda$CUVER
+        pip install cupy-cuda$CUVER
     - run: pytest
     - run: codecov
     - name: Post Run setup-python

--- a/README.rst
+++ b/README.rst
@@ -5,6 +5,10 @@ Unifying Python/C++/CUDA memory: Python buffered array <-> C++11 ``std::vector``
 
 |Version| |Downloads| |Py-Versions| |DOI| |Licence| |Tests| |Coverage|
 
+.. contents:: Table of contents
+   :backlinks: top
+   :local:
+
 Why
 ~~~
 

--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,8 @@ Anything to do with mathematical functionality. The aim is to expose functionali
 Even something as simple as setting element values is left to the user and/or pre-existing features - for example:
 
 - Python: ``arr[:] = value``
-- Numpy: ``arr.fill(value)``
+- NumPy: ``arr.fill(value)``
+- CuPy: ``cupy.asarray(arr).fill(value)``
 - C++: ``std::fill(vec.begin(), vec.end(), value)``
 - C/CUDA: ``memset(vec.data(), value, sizeof(T) * vec.size())``
 

--- a/README.rst
+++ b/README.rst
@@ -55,10 +55,6 @@ Creating
     # some_cpython_api_func(arr.cuvec)
     # import cupy; cupy_arr = cupy.asarray(arr)
 
-Note that ``arr`` contains all the attributes of a ``numpy.ndarray``.
-Additionally, ``arr.cuvec`` implements the `buffer protocol <https://docs.python.org/3/c-api/buffer.html>`_, while
-``arr.__cuda_array_interface__`` provides `compatibility with other libraries  <https://numba.readthedocs.io/en/latest/cuda/cuda_array_interface.html>`_ such as Numba, CuPy, PyTorch, PyArrow, and RAPIDS.
-
 **CPython API**
 
 .. code:: cpp
@@ -117,8 +113,18 @@ The following involve no memory copies.
     /// output: `type *arr`
     float *arr = vec.data(); // pointer to `cudaMallocManaged()` data
 
-External C++/CUDA Projects
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+External Projects
+~~~~~~~~~~~~~~~~~
+
+Python Projects
+---------------
+
+Python objects (``arr``, returned by ``cuvec.zeros()``, ``cuvec.asarray()``, or ``cuvec.copy()``) contain all the attributes of a ``numpy.ndarray``.
+Additionally, ``arr.cuvec`` implements the `buffer protocol <https://docs.python.org/3/c-api/buffer.html>`_, while
+``arr.__cuda_array_interface__`` provides `compatibility with other libraries  <https://numba.readthedocs.io/en/latest/cuda/cuda_array_interface.html>`_ such as Numba, CuPy, PyTorch, PyArrow, and RAPIDS.
+
+C++/CUDA Projects
+-----------------
 
 ``cuvec`` is a header-only library so simply ``#include "pycuvec.cuh"``
 (or ``#include "cuvec.cuh"``). You can find the location of the headers using:
@@ -127,8 +133,8 @@ External C++/CUDA Projects
 
     python -c "import cuvec; print(cuvec.include_path)"
 
-External CMake Projects
-~~~~~~~~~~~~~~~~~~~~~~~
+CMake Projects
+--------------
 
 This is likely unnecessary (see above).
 

--- a/README.rst
+++ b/README.rst
@@ -53,6 +53,11 @@ Creating
     # print(sum(arr))
     # some_numpy_func(arr)
     # some_cpython_api_func(arr.cuvec)
+    # import cupy; cupy_arr = cupy.asarray(arr)
+
+Note that ``arr`` contains all the attributes of a ``numpy.ndarray``.
+Additionally, ``arr.cuvec`` implements the `buffer protocol <https://docs.python.org/3/c-api/buffer.html>`_, while
+``arr.__cuda_array_interface__`` provides `compatibility with other libraries  <https://numba.readthedocs.io/en/latest/cuda/cuda_array_interface.html>`_ such as Numba, CuPy, PyTorch, PyArrow, and RAPIDS.
 
 **CPython API**
 

--- a/cuvec/helpers.py
+++ b/cuvec/helpers.py
@@ -49,6 +49,12 @@ class CuVec(np.ndarray):
             (do not do `cuvec.CuVec((42, 1337))`;
             instead use `cuvec.zeros((42, 137))`"""))
 
+    @property
+    def __cuda_array_interface__(self):
+        res = self.__array_interface__
+        return {
+            'shape': res['shape'], 'typestr': res['typestr'], 'data': res['data'], 'version': 3}
+
 
 def zeros(shape, dtype="float32"):
     """

--- a/cuvec/helpers.py
+++ b/cuvec/helpers.py
@@ -51,6 +51,11 @@ class CuVec(np.ndarray):
 
     @property
     def __cuda_array_interface__(self):
+        if not hasattr(self, 'cuvec'):
+            raise AttributeError(
+                dedent("""\
+                `numpy.ndarray` object has no attribute `cuvec`:
+                try using `cuvec.asarray()` first."""))
         res = self.__array_interface__
         return {
             'shape': res['shape'], 'typestr': res['typestr'], 'data': res['data'], 'version': 3}

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -86,10 +86,17 @@ def test_asarray():
 def test_cuda_array_interface():
     cupy = importorskip("cupy")
     v = cu.asarray(np.random.random(shape))
-    c = cupy.asarray(v)
+    assert hasattr(v, '__cuda_array_interface__')
 
+    c = cupy.asarray(v)
     assert (c == v).all()
     c[0, 0, 0] = 1
     assert c[0, 0, 0] == v[0, 0, 0]
     c[0, 0, 0] = 0
     assert c[0, 0, 0] == v[0, 0, 0]
+
+    ndarr = v + 1
+    assert ndarr.shape == v.shape
+    assert ndarr.dtype == v.dtype
+    with raises(AttributeError):
+        ndarr.__cuda_array_interface__

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,7 +1,7 @@
 import logging
 
 import numpy as np
-from pytest import mark, raises
+from pytest import importorskip, mark, raises
 
 import cuvec as cu
 
@@ -81,3 +81,15 @@ def test_asarray():
     assert s.cuvec != v.cuvec
     assert (s == v[1:]).all()
     assert np.asarray(s.cuvec).data != np.asarray(v.cuvec).data
+
+
+def test_cuda_array_interface():
+    cupy = importorskip("cupy")
+    v = cu.asarray(np.random.random(shape))
+    c = cupy.asarray(v)
+
+    assert (c == v).all()
+    c[0, 0, 0] = 1
+    assert c[0, 0, 0] == v[0, 0, 0]
+    c[0, 0, 0] = 0
+    assert c[0, 0, 0] == v[0, 0, 0]


### PR DESCRIPTION
- add `__cuda_array_interface__` (#4)
- add tests
- update documentation

----

- fixes #4

Allows for seamless integration with other libraries, e.g.:

```python
import cuvec, cupy
v = cuvec.zeros((42, 1337), 'float32')
c = cupy.asarray(v)
c[0, 0] = 1
assert c[0, 0] == v[0, 0]
```