### PR TITLE
next release: v2.6.0

### DIFF
--- a/cuvec/CMakeLists.txt
+++ b/cuvec/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 if("${CUVEC_BUILD_VERSION}" STREQUAL "")
-  set(CUVEC_BUILD_VERSION 1 CACHE STRING "version" FORCE)
+  set(CUVEC_BUILD_VERSION 2 CACHE STRING "version" FORCE)
 endif()
 project(cuvec LANGUAGES C CXX CUDA VERSION "${CUVEC_BUILD_VERSION}")
 
@@ -67,8 +67,8 @@ install(TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME}Targets
 install(EXPORT ${PROJECT_NAME}Targets FILE AMYPAD${PROJECT_NAME}Targets.cmake
   NAMESPACE AMYPAD:: DESTINATION ${CMAKE_PROJECT_NAME}/cmake)
 
-# alternative swvec package
-if(SWIG_FOUND)
+# alternative swvec module
+if(SWIG_FOUND AND SKBUILD)
   include_directories(${CUDAToolkit_INCLUDE_DIRS})
   set_source_files_properties(src/swvec.i PROPERTIES CPLUSPLUS ON)
   set_source_files_properties(src/swvec.i PROPERTIES USE_TARGET_INCLUDE_DIRECTORIES ON)
@@ -77,19 +77,15 @@ if(SWIG_FOUND)
   target_include_directories(swvec PUBLIC
     "$<BUILD_INTERFACE:${${CMAKE_PROJECT_NAME}_INCLUDE_DIRS}>"
     "$<INSTALL_INTERFACE:${CMAKE_PROJECT_NAME}/include>")
-  if(SKBUILD)
-    python_extension_module(swvec)
-  endif()
+  python_extension_module(swvec)
   set_target_properties(swvec PROPERTIES
     CXX_STANDARD 11
     VERSION ${CMAKE_PROJECT_VERSION} SOVERSION ${CMAKE_PROJECT_VERSION_MAJOR}
     INTERFACE_swvec_MAJOR_VERSION ${CMAKE_PROJECT_VERSION_MAJOR})
   set_property(TARGET swvec APPEND PROPERTY COMPATIBLE_INTERFACE_STRING swvec_MAJOR_VERSION)
-  install(TARGETS swvec EXPORT swvecTargets
+  install(TARGETS swvec
     INCLUDES DESTINATION ${CMAKE_PROJECT_NAME}/include
     LIBRARY DESTINATION ${CMAKE_PROJECT_NAME})
-  install(EXPORT swvecTargets FILE AMYPADswvecTargets.cmake
-    NAMESPACE AMYPAD:: DESTINATION ${CMAKE_PROJECT_NAME}/cmake)
 endif()
 
 add_subdirectory(src/example_mod)

--- a/cuvec/CMakeLists.txt
+++ b/cuvec/CMakeLists.txt
@@ -67,6 +67,31 @@ install(TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME}Targets
 install(EXPORT ${PROJECT_NAME}Targets FILE AMYPAD${PROJECT_NAME}Targets.cmake
   NAMESPACE AMYPAD:: DESTINATION ${CMAKE_PROJECT_NAME}/cmake)
 
+# alternative swvec package
+if(SWIG_FOUND)
+  include_directories(${CUDAToolkit_INCLUDE_DIRS})
+  set_source_files_properties(src/swvec.i PROPERTIES CPLUSPLUS ON)
+  set_source_files_properties(src/swvec.i PROPERTIES USE_TARGET_INCLUDE_DIRECTORIES ON)
+  swig_add_library(swvec LANGUAGE python SOURCES src/swvec.i)
+  swig_link_libraries(swvec CUDA::cudart_static)
+  target_include_directories(swvec PUBLIC
+    "$<BUILD_INTERFACE:${${CMAKE_PROJECT_NAME}_INCLUDE_DIRS}>"
+    "$<INSTALL_INTERFACE:${CMAKE_PROJECT_NAME}/include>")
+  if(SKBUILD)
+    python_extension_module(swvec)
+  endif()
+  set_target_properties(swvec PROPERTIES
+    CXX_STANDARD 11
+    VERSION ${CMAKE_PROJECT_VERSION} SOVERSION ${CMAKE_PROJECT_VERSION_MAJOR}
+    INTERFACE_swvec_MAJOR_VERSION ${CMAKE_PROJECT_VERSION_MAJOR})
+  set_property(TARGET swvec APPEND PROPERTY COMPATIBLE_INTERFACE_STRING swvec_MAJOR_VERSION)
+  install(TARGETS swvec EXPORT swvecTargets
+    INCLUDES DESTINATION ${CMAKE_PROJECT_NAME}/include
+    LIBRARY DESTINATION ${CMAKE_PROJECT_NAME})
+  install(EXPORT swvecTargets FILE AMYPADswvecTargets.cmake
+    NAMESPACE AMYPAD:: DESTINATION ${CMAKE_PROJECT_NAME}/cmake)
+endif()
+
 add_subdirectory(src/example_mod)
 add_subdirectory(src/example_swig)
 

--- a/cuvec/include/cuvec.cuh
+++ b/cuvec/include/cuvec.cuh
@@ -1,6 +1,14 @@
 /**
- * Pure CUDA/C++11 template header providing `CuVec`
- * (anaologous to `std::vector` but using CUDA unified memory).
+ * Pure CUDA/C++11 template header. Provides:
+ * - CuVec<T> // analogous to `std::vector` but using CUDA unified memory
+ *
+ * SWIG helpers wrapping `CuVec<T>`. Provides:
+ * - SwigCuVec<T> // contains `CuVec<T> vec` and `std::vector<size_t> shape`
+ * - SwigCuVec<T> *SwigCuVec_new(std::vector<size_t> shape)
+ * - void SwigCuVec_del(SwigCuVec<T> *self)
+ * - T *SwigCuVec_data(SwigCuVec<T> *self)
+ * - size_t SwigCuVec_address(SwigCuVec<T> *self)
+ * - std::vector<size_t> SwigCuVec_shape(SwigCuVec<T> *self)
  */
 #ifndef _CUVEC_H_
 #define _CUVEC_H_
@@ -67,5 +75,30 @@ template <class T, class U> bool operator!=(const CuAlloc<T> &, const CuAlloc<U>
 }
 
 template <class T> using CuVec = std::vector<T, CuAlloc<T>>;
+
+template <class T> struct SwigCuVec {
+  CuVec<T> vec;
+  std::vector<size_t> shape;
+};
+template <class T> SwigCuVec<T> *SwigCuVec_new(std::vector<size_t> shape) {
+  SwigCuVec<T> *self = new SwigCuVec<T>;
+  self->shape = shape;
+  size_t size = 1;
+  for (auto &i : shape) size *= i;
+  self->vec.resize(size);
+  return self;
+}
+template <class T> void SwigCuVec_del(SwigCuVec<T> *self) {
+  self->vec.clear();
+  self->vec.shrink_to_fit();
+  self->shape.clear();
+  self->shape.shrink_to_fit();
+  delete self;
+}
+template <class T> T *SwigCuVec_data(SwigCuVec<T> *self) { return self->vec.data(); }
+template <class T> size_t SwigCuVec_address(SwigCuVec<T> *self) {
+  return (size_t)SwigCuVec_data(self);
+}
+template <class T> std::vector<size_t> SwigCuVec_shape(SwigCuVec<T> *self) { return self->shape; }
 
 #endif // _CUVEC_H_

--- a/cuvec/include/cuvec.i
+++ b/cuvec/include/cuvec.i
@@ -13,30 +13,3 @@ template <class T> struct SwigCuVec {
   CuVec<T> vec;
   std::vector<size_t> shape;
 };
-template <class T> SwigCuVec<T> *SwigCuVec_new(std::vector<size_t> shape);
-template <class T> void SwigCuVec_del(SwigCuVec<T> *self);
-template <class T> T *SwigCuVec_data(SwigCuVec<T> *self);
-template <class T> size_t SwigCuVec_address(SwigCuVec<T> *self);
-template <class T> std::vector<size_t> SwigCuVec_shape(SwigCuVec<T> *self);
-
-%template(SwigCuVec_Shape) std::vector<size_t>;
-%define MKCUVEC(T, typechar)
-%template(SwigCuVec_ ## typechar) SwigCuVec<T>;
-%template(SwigCuVec_ ## typechar ## _new) SwigCuVec_new<T>;
-%template(SwigCuVec_ ## typechar ## _del) SwigCuVec_del<T>;
-%template(SwigCuVec_ ## typechar ## _data) SwigCuVec_data<T>;
-%template(SwigCuVec_ ## typechar ## _address) SwigCuVec_address<T>;
-%template(SwigCuVec_ ## typechar ## _shape) SwigCuVec_shape<T>;
-%enddef
-MKCUVEC(signed char, b)
-MKCUVEC(unsigned char, B)
-MKCUVEC(char, c)
-MKCUVEC(short, h)
-MKCUVEC(unsigned short, H)
-MKCUVEC(int, i)
-MKCUVEC(unsigned int, I)
-MKCUVEC(long long, q)
-MKCUVEC(unsigned long long, Q)
-MKCUVEC(__half, e)
-MKCUVEC(float, f)
-MKCUVEC(double, d)

--- a/cuvec/include/cuvec.i
+++ b/cuvec/include/cuvec.i
@@ -1,30 +1,32 @@
 /**
- * SWIG template header wrapping `CuVec<T>`. Provides:
- *     CuVec(T)
+ * SWIG template header wrapping `SwigCuVec<T>` as defined in "cuvec.cuh"
  * for external use via `%include "cuvec.i"`.
- * Note that `CuVec(T)` is `%define`d to be `CuVec<T>`, which in turn is
- * defined in "cuvec.cuh"
  */
 %include "std_vector.i"
 
 %{
-#include "cuvec.cuh"    // CuAlloc
-#include "cuda_fp16.h"  // __half
-
-template<class T> size_t data(CuVec<T> &vec) {
-  return (size_t) vec.data();
-};
+#include "cuvec.cuh"   // SwigCuVec<T>
+#include "cuda_fp16.h" // __half
 %}
 
-/// `%define X Y` rather than `using X = Y;`
-/// due to https://github.com/swig/swig/issues/1058
-%define CuVec(T) std::vector<T, CuAlloc<T>> %enddef
+template <class T> struct SwigCuVec {
+  CuVec<T> vec;
+  std::vector<size_t> shape;
+};
+template <class T> SwigCuVec<T> *SwigCuVec_new(std::vector<size_t> shape);
+template <class T> void SwigCuVec_del(SwigCuVec<T> *self);
+template <class T> T *SwigCuVec_data(SwigCuVec<T> *self);
+template <class T> size_t SwigCuVec_address(SwigCuVec<T> *self);
+template <class T> std::vector<size_t> SwigCuVec_shape(SwigCuVec<T> *self);
 
-template<class T> size_t data(CuVec(T) &vec);
-
+%template(SwigCuVec_Shape) std::vector<size_t>;
 %define MKCUVEC(T, typechar)
-%template(CuVec_ ## typechar) CuVec(T);
-%template(CuVec_ ## typechar ## _data) data<T>;
+%template(SwigCuVec_ ## typechar) SwigCuVec<T>;
+%template(SwigCuVec_ ## typechar ## _new) SwigCuVec_new<T>;
+%template(SwigCuVec_ ## typechar ## _del) SwigCuVec_del<T>;
+%template(SwigCuVec_ ## typechar ## _data) SwigCuVec_data<T>;
+%template(SwigCuVec_ ## typechar ## _address) SwigCuVec_address<T>;
+%template(SwigCuVec_ ## typechar ## _shape) SwigCuVec_shape<T>;
 %enddef
 MKCUVEC(signed char, b)
 MKCUVEC(unsigned char, B)

--- a/cuvec/include/cuvec.i
+++ b/cuvec/include/cuvec.i
@@ -6,7 +6,6 @@
 
 %{
 #include "cuvec.cuh"   // SwigCuVec<T>
-#include "cuda_fp16.h" // __half
 %}
 
 template <class T> struct SwigCuVec {

--- a/cuvec/src/example_swig/example_swig.cu
+++ b/cuvec/src/example_swig/example_swig.cu
@@ -3,7 +3,7 @@
  *
  * Copyright (2021) Casper da Costa-Luis
  */
-#include "cuvec.cuh" // SwigCuVec
+#include "cuvec.cuh" // SwigCuVec, SwigCuVec_new
 #include <stdexcept> // std::length_error
 /// dst = src + 1
 __global__ void _d_incr(float *dst, float *src, int X, int Y) {
@@ -13,8 +13,8 @@ __global__ void _d_incr(float *dst, float *src, int X, int Y) {
   if (y >= Y) return;
   dst[y * X + x] = src[y * X + x] + 1;
 }
-SwigCuVec<float> *increment2d_f(SwigCuVec<float> *src, bool timing, SwigCuVec<float> *output) {
-  auto &N = src->shape;
+SwigCuVec<float> *increment2d_f(SwigCuVec<float> &src, SwigCuVec<float> *output, bool timing) {
+  auto &N = src.shape;
   if (N.size() != 2) throw std::length_error("`src` must be 2D");
 
   cudaEvent_t eStart, eAlloc, eKern;
@@ -22,15 +22,14 @@ SwigCuVec<float> *increment2d_f(SwigCuVec<float> *src, bool timing, SwigCuVec<fl
   cudaEventCreate(&eAlloc);
   cudaEventCreate(&eKern);
   cudaEventRecord(eStart);
-  if (output) {
-    if (N != output->shape) throw std::length_error("`output` must be same shape as `src`");
-  } else {
-    output = SwigCuVec_new<float>(src->shape);
-  }
+  if (!output)
+    output = SwigCuVec_new<float>(N);
+  else if (N != output->shape)
+    throw std::length_error("`output` must be same shape as `src`");
   cudaEventRecord(eAlloc);
   dim3 thrds((N[1] + 31) / 32, (N[0] + 31) / 32);
   dim3 blcks(32, 32);
-  _d_incr<<<thrds, blcks>>>(output->vec.data(), src->vec.data(), N[1], N[0]);
+  _d_incr<<<thrds, blcks>>>(output->vec.data(), src.vec.data(), N[1], N[0]);
   cuvec::HandleError(cudaGetLastError(), __FILE__, __LINE__);
   // cudaDeviceSynchronize();
   cudaEventRecord(eKern);

--- a/cuvec/src/example_swig/example_swig.cu
+++ b/cuvec/src/example_swig/example_swig.cu
@@ -3,30 +3,34 @@
  *
  * Copyright (2021) Casper da Costa-Luis
  */
-#include "cuvec.cuh" // CuVec
+#include "cuvec.cuh" // SwigCuVec
 #include <stdexcept> // std::length_error
-/** functions */
 /// dst = src + 1
-__global__ void _d_incr(float *dst, float *src, int N) {
-  int i = threadIdx.x + blockDim.x * blockIdx.x;
-  if (i >= N) return;
-  dst[i] = src[i] + 1;
+__global__ void _d_incr(float *dst, float *src, int X, int Y) {
+  int x = threadIdx.x + blockDim.x * blockIdx.x;
+  if (x >= X) return;
+  int y = threadIdx.y + blockDim.y * blockIdx.y;
+  if (y >= Y) return;
+  dst[y * X + x] = src[y * X + x] + 1;
 }
-CuVec<float> *increment_f(CuVec<float> &src, CuVec<float> *dst, bool timing) {
+SwigCuVec<float> *increment2d_f(SwigCuVec<float> *src, bool timing, SwigCuVec<float> *output) {
+  auto &N = src->shape;
+  if (N.size() != 2) throw std::length_error("`src` must be 2D");
+
   cudaEvent_t eStart, eAlloc, eKern;
   cudaEventCreate(&eStart);
   cudaEventCreate(&eAlloc);
   cudaEventCreate(&eKern);
   cudaEventRecord(eStart);
-  if (!dst) {
-    dst = new CuVec<float>;
-    dst->resize(src.size());
+  if (output) {
+    if (N != output->shape) throw std::length_error("`output` must be same shape as `src`");
+  } else {
+    output = SwigCuVec_new<float>(src->shape);
   }
-  if (src.size() != dst->size()) throw std::length_error("`output` must be same shape as `src`");
   cudaEventRecord(eAlloc);
-  dim3 thrds((src.size() + 1023) / 1024, 1, 1);
-  dim3 blcks(1024, 1, 1);
-  _d_incr<<<thrds, blcks>>>(dst->data(), src.data(), src.size());
+  dim3 thrds((N[1] + 31) / 32, (N[0] + 31) / 32);
+  dim3 blcks(32, 32);
+  _d_incr<<<thrds, blcks>>>(output->vec.data(), src->vec.data(), N[1], N[0]);
   cuvec::HandleError(cudaGetLastError(), __FILE__, __LINE__);
   // cudaDeviceSynchronize();
   cudaEventRecord(eKern);
@@ -36,9 +40,9 @@ CuVec<float> *increment_f(CuVec<float> &src, CuVec<float> *dst, bool timing) {
   cudaEventElapsedTime(&kernel_ms, eAlloc, eKern);
   // fprintf(stderr, "%.3f ms, %.3f ms\n", alloc_ms, kernel_ms);
   if (timing) {
-    // hack: store times in last two elements of dst
-    (*dst)[src.size() - 2] = alloc_ms;
-    (*dst)[src.size() - 1] = kernel_ms;
+    // hack: store times in first two elements of output
+    output->vec[0] = alloc_ms;
+    output->vec[1] = kernel_ms;
   }
-  return dst;
+  return output;
 }

--- a/cuvec/src/example_swig/example_swig.i
+++ b/cuvec/src/example_swig/example_swig.i
@@ -9,10 +9,10 @@
   }
 }
 
-%include "cuvec.i" // %{ CuVec<T> %}, CuVec(T)
+%include "cuvec.i" // SwigCuVec<T>
 %{
 /// signatures from "example_swig.cu"
-CuVec<float> *increment_f(CuVec<float> &src, CuVec<float> *output = NULL, bool timing = false);
+SwigCuVec<float> *increment2d_f(SwigCuVec<float> *src, bool timing = false, SwigCuVec<float> *output = NULL);
 %}
 /// expose definitions
-CuVec(float) *increment_f(CuVec(float) &src, CuVec(float) *output = NULL, bool timing = false);
+SwigCuVec<float> *increment2d_f(SwigCuVec<float> *src, bool timing = false, SwigCuVec<float> *output = NULL);

--- a/cuvec/src/example_swig/example_swig.i
+++ b/cuvec/src/example_swig/example_swig.i
@@ -12,7 +12,7 @@
 %include "cuvec.i" // SwigCuVec<T>
 %{
 /// signatures from "example_swig.cu"
-SwigCuVec<float> *increment2d_f(SwigCuVec<float> *src, bool timing = false, SwigCuVec<float> *output = NULL);
+SwigCuVec<float> *increment2d_f(SwigCuVec<float> &src, SwigCuVec<float> *output = NULL, bool timing = false);
 %}
 /// expose definitions
-SwigCuVec<float> *increment2d_f(SwigCuVec<float> *src, bool timing = false, SwigCuVec<float> *output = NULL);
+SwigCuVec<float> *increment2d_f(SwigCuVec<float> &src, SwigCuVec<float> *output = NULL, bool timing = false);

--- a/cuvec/src/swvec.i
+++ b/cuvec/src/swvec.i
@@ -9,6 +9,10 @@
   }
 }
 
+%{
+#include "cuda_fp16.h" // __half
+%}
+
 %include "cuvec.i" // SwigCuVec<T>
 
 template <class T> SwigCuVec<T> *SwigCuVec_new(std::vector<size_t> shape);

--- a/cuvec/src/swvec.i
+++ b/cuvec/src/swvec.i
@@ -1,0 +1,40 @@
+%module swvec
+
+%include "exception.i"
+%exception {
+  try {
+    $action
+  } catch (const std::exception &e) {
+    SWIG_exception(SWIG_RuntimeError, e.what());
+  }
+}
+
+%include "cuvec.i" // SwigCuVec<T>
+
+template <class T> SwigCuVec<T> *SwigCuVec_new(std::vector<size_t> shape);
+template <class T> void SwigCuVec_del(SwigCuVec<T> *self);
+template <class T> T *SwigCuVec_data(SwigCuVec<T> *self);
+template <class T> size_t SwigCuVec_address(SwigCuVec<T> *self);
+template <class T> std::vector<size_t> SwigCuVec_shape(SwigCuVec<T> *self);
+
+%template(SwigCuVec_Shape) std::vector<size_t>;
+%define MKCUVEC(T, typechar)
+%template(SwigCuVec_ ## typechar) SwigCuVec<T>;
+%template(SwigCuVec_ ## typechar ## _new) SwigCuVec_new<T>;
+%template(SwigCuVec_ ## typechar ## _del) SwigCuVec_del<T>;
+%template(SwigCuVec_ ## typechar ## _data) SwigCuVec_data<T>;
+%template(SwigCuVec_ ## typechar ## _address) SwigCuVec_address<T>;
+%template(SwigCuVec_ ## typechar ## _shape) SwigCuVec_shape<T>;
+%enddef
+MKCUVEC(signed char, b)
+MKCUVEC(unsigned char, B)
+MKCUVEC(char, c)
+MKCUVEC(short, h)
+MKCUVEC(unsigned short, H)
+MKCUVEC(int, i)
+MKCUVEC(unsigned int, I)
+MKCUVEC(long long, q)
+MKCUVEC(unsigned long long, Q)
+MKCUVEC(__half, e)
+MKCUVEC(float, f)
+MKCUVEC(double, d)

--- a/cuvec/swigcuvec.py
+++ b/cuvec/swigcuvec.py
@@ -1,5 +1,5 @@
 """
-Thin wrappers around `example_swig` C++/CUDA module
+Thin wrappers around `swvec` C++/CUDA module
 
 A SWIG-driven equivalent of the CPython Extension API-driven `pycuvec.py`
 """
@@ -12,7 +12,7 @@ from textwrap import dedent
 
 import numpy as np
 
-from . import example_swig as sw
+from . import swvec as sw
 
 log = logging.getLogger(__name__)
 # u: non-standard np.dype('S2'); l/L: inconsistent between `array` and `numpy`

--- a/tests/test_perf.py
+++ b/tests/test_perf.py
@@ -68,12 +68,12 @@ def test_perf(cu, ex, shape=(1337, 42), quiet=False):
 
     if not quiet:
         if cu is sw:
-            t['warmup'], res = timer(ex.increment2d_f)(src.cuvec, True)
+            t['warmup'], res = timer(ex.increment2d_f)(src.cuvec, None, True)
             t['> create dst'], t['> kernel'] = cu.asarray(res)[0, :2]
         else:
             t['warmup'], (t['> create dst'], t['> kernel'], _) = timer(ex.increment2d_f)(src.cuvec)
     if cu is sw:
-        t['call ext'], res = timer(ex.increment2d_f)(src.cuvec, True)
+        t['call ext'], res = timer(ex.increment2d_f)(src.cuvec, None, True)
         t['- create dst'], t['- kernel'] = None, None
         t['view'], dst = timer(cu.asarray)(res)
         t['- create dst'], t['- kernel'] = dst[0, :2]

--- a/tests/test_swigcuvec.py
+++ b/tests/test_swigcuvec.py
@@ -145,7 +145,7 @@ def test_increment():
     from cuvec.example_swig import increment2d_f
     a = cu.zeros((1337, 42), 'f')
     assert (a == 0).all()
-    increment2d_f(a.cuvec, False, a.cuvec)
+    increment2d_f(a.cuvec, a.cuvec)
     assert (a == 1).all()
 
     a[:] = 0

--- a/tests/test_swigcuvec.py
+++ b/tests/test_swigcuvec.py
@@ -142,14 +142,14 @@ def test_cuda_array_interface():
 
 def test_increment():
     # `example_swig` is defined in ../cuvec/src/example_swig/
-    from cuvec.example_swig import increment_f
-    a = cu.zeros(shape, 'f')
+    from cuvec.example_swig import increment2d_f
+    a = cu.zeros((1337, 42), 'f')
     assert (a == 0).all()
-    increment_f(a.cuvec, a.cuvec)
+    increment2d_f(a.cuvec, False, a.cuvec)
     assert (a == 1).all()
 
     a[:] = 0
     assert (a == 0).all()
 
-    res = cu.asarray(increment_f(a.cuvec))
+    res = cu.asarray(increment2d_f(a.cuvec))
     assert (res == 1).all()

--- a/tests/test_swigcuvec.py
+++ b/tests/test_swigcuvec.py
@@ -11,20 +11,21 @@ shape = 127, 344, 344
 
 @mark.parametrize("tp", list(cu.typecodes))
 def test_SWIGVector_asarray(tp):
-    v = cu.SWIGVector(tp, 1337)
-    assert repr(v) == f"SWIGVector('{tp}', 1337)"
+    v = cu.SWIGVector(tp, (1, 2, 3))
+    assert repr(v) == f"SWIGVector('{tp}', (1, 2, 3))"
     a = np.asarray(v)
     assert not a.any()
-    a[:7] = 42
+    a[0, 0] = 42
     b = np.asarray(v)
-    assert (b[:7] == 42).all()
-    assert not b[7:].any()
+    assert (b[0, 0] == 42).all()
+    assert not b[1:, 1:].any()
     assert a.dtype == np.dtype(tp)
     del a, b, v
 
 
-def test_strides():
-    a = cu.zeros(shape)
+def test_PyCuVec_strides():
+    v = cu.SWIGVector('f', shape)
+    a = np.asarray(v)
     assert a.shape == shape
     assert a.strides == (473344, 1376, 4)
 
@@ -89,7 +90,6 @@ def test_asarray():
     assert str(w.swvec) == str(v.swvec)
     assert np.asarray(w.swvec).data == np.asarray(v.swvec).data
     x = cu.asarray(w.swvec)
-    x.resize(w.shape)
     assert x.cuvec == v.cuvec
     assert (x == v).all()
     assert str(x.swvec) == str(v.swvec)
@@ -126,12 +126,12 @@ def test_cuda_array_interface():
     assert c[0, 0, 0] == v[0, 0, 0]
 
     d = cupy.asarray(v.swvec)
-    d[0] = 1
+    d[0, 0, 0] = 1
     dev_sync()
-    assert d[0] == v[0, 0, 0]
-    d[0] = 0
+    assert d[0, 0, 0] == v[0, 0, 0]
+    d[0, 0, 0] = 0
     dev_sync()
-    assert d[0] == v[0, 0, 0]
+    assert d[0, 0, 0] == v[0, 0, 0]
 
     ndarr = v + 1
     assert ndarr.shape == v.shape


### PR DESCRIPTION
- major SWIG updates
  + expose `SwigCuVec<T>`
  + separate core (`swvec.i`) & example (`example_swig.i`) modules
  + update tests & examples
- update & tidy performance tests