### PR TITLE
Fix broken editable install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4",
+requires = ["setuptools>=42,<64", "wheel", "setuptools_scm[toml]>=3.4",
             "miutil[cuda]>=0.4.0",
             "scikit-build>=0.11.0", "cmake>=3.18", "ninja"]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ classifiers=
     Topic :: Utilities
 [options]
 setup_requires=
-    setuptools>=42
+    setuptools>=42,<64
     wheel
     setuptools_scm[toml]
     miutil[cuda]>=0.4.0


### PR DESCRIPTION
This pull request pins `setuptools` to versions older than [`64`](https://github.com/pypa/setuptools/releases/tag/v64.0.0) in order to fix broken editable installs due to PEP-660 implementation. See https://github.com/pypa/setuptools/pull/3488 for more information.