### PR TITLE
dist: PyPI trusted publish, docs: in-place dev builds

### DIFF
--- a/.github/workflows/comment-bot.yml
+++ b/.github/workflows/comment-bot.yml
@@ -6,6 +6,10 @@ jobs:
   tag:  # /tag <tagname> <commit>
     if: startsWith(github.event.comment.body, '/tag ')
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
     steps:
     - uses: actions/checkout@v4
     - name: React Seen
@@ -27,7 +31,6 @@ jobs:
           post({
             owner: context.repo.owner, repo: context.repo.repo,
             comment_id: context.payload.comment.id, content: "eyes"})
-        github-token: ${{ secrets.GH_TOKEN }}
     - name: Tag Commit
       run: |
         git clone https://${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY} repo
@@ -47,4 +50,3 @@ jobs:
           post({
             owner: context.repo.owner, repo: context.repo.repo,
             comment_id: context.payload.comment.id, content: "rocket"})
-        github-token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -113,6 +113,10 @@ jobs:
   deploy:
     needs: [check, test, cuda]
     name: PyPI Deploy
+    environment: pypi
+    permissions:
+      contents: write
+      id-token: write
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -126,8 +130,9 @@ jobs:
       uses: casperdcl/deploy-pypi@v2
       with:
         build: -s
-        password: ${{ secrets.PYPI_TOKEN }}
-        upload: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags') }}
+        upload: false
+    - if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+      uses: pypa/gh-action-pypi-publish@release/v1
     - if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
       name: Release
       run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,20 +4,30 @@ Install in "development/editable" mode including dev/test dependencies:
 
 ```sh
 git clone https://github.com/AMYPAD/CuVec && cd CuVec
-export SETUPTOOLS_ENABLE_FEATURES=legacy-editable
-pip install -e .[dev]
-```
 
-Alternatively, if `cmake` and a generator (such as `make` or `ninja`) are
-available, then `setup.py build` and `develop` can be explicitly called;
-optionally with extra `cmake` and generator arguments:
-
-```sh
-python setup.py build develop easy_install cuvec[dev] -- -DCUVEC_DEBUG:BOOL=ON -- -j8
+# `pip install -e .[dev]` won't work due to https://github.com/scikit-build/scikit-build-core/issues/114
+# work-around:
+# 1. install dependencies (one-off)
+pip install toml
+python -c 'import toml; c=toml.load("pyproject.toml")
+print("\0".join(c["build-system"]["requires"] + c["project"]["dependencies"] + c["project"]["optional-dependencies"]["dev"]), end="")' \
+| xargs -0 pip install -U ninja cmake
+# 2. delete build artefacts, (re)build & install in-place with debug info
+git clean -Xdf
+pip install --no-build-isolation --no-deps -t . -U -v . \
+  -Ccmake.define.CUVEC_DEBUG=1
+  -Ccmake.define.CMAKE_CXX_FLAGS="-Wall -Wextra -Wpedantic -Werror -Wno-missing-field-initializers -Wno-unused-parameter -Wno-cast-function-type"
+git restore cuvec/src # undo deletion of sources
 ```
 
 Once installed in development/editable mode, tests may be run using:
 
 ```sh
 pytest
+```
+
+To run performance tests, build with debugging disabled (`CUVEC_DEBUG=0`), then run:
+
+```sh
+python tests/test_perf.py
 ```


### PR DESCRIPTION
- use [PyPI trusted publisher releases](https://docs.pypi.org/trusted-publishers/adding-a-publisher)
- update contributing docs/instructions for in-place local builds (follow-up to #34)
