### PR TITLE
CPU-only alternative

### DIFF
--- a/cuvec/include/cuvec.cuh
+++ b/cuvec/include/cuvec.cuh
@@ -82,7 +82,7 @@ template <class T, class U> bool operator!=(const CuAlloc<T> &, const CuAlloc<U>
   return false;
 }
 
-template <class T> using CuVec = std::vector<T, CuAlloc<T>>;
+template <class T, class Alloc = CuAlloc<T>> using CuVec = std::vector<T, Alloc>;
 
 /// extension helpers
 #ifndef _CUVEC_HALF
@@ -97,8 +97,8 @@ template <class T> using CuVec = std::vector<T, CuAlloc<T>>;
 #endif // _CUVEC_HALF
 
 /// external wrapper helper
-template <class T> struct NDCuVec {
-  CuVec<T> vec;
+template <class T, class Alloc = CuAlloc<T>> struct NDCuVec {
+  CuVec<T, Alloc> vec;
   std::vector<size_t> shape;
   NDCuVec() = default;
   NDCuVec(const std::vector<size_t> &shape) : shape(shape) {
@@ -120,5 +120,9 @@ template <class T> struct NDCuVec {
     return s;
   }
 };
+
+/// CPU-only versions
+template <class T> using CVec = std::vector<T, std::allocator<T>>;
+template <class T> using NDCVec = NDCuVec<T, std::allocator<T>>;
 
 #endif // _CUVEC_H_

--- a/cuvec/src/pybind11.cu
+++ b/cuvec/src/pybind11.cu
@@ -11,20 +11,20 @@ PYBIND11_MODULE(cuvec_pybind11, m) {
   m.doc() = "PyBind11 external module.";
   pybind11::bind_vector<std::vector<size_t>>(m, "Shape");
   pybind11::implicitly_convertible<pybind11::tuple, std::vector<size_t>>();
-  PYBIND11_BIND_NDCUVEC(signed char, b);
-  PYBIND11_BIND_NDCUVEC(unsigned char, B);
-  PYBIND11_BIND_NDCUVEC(char, c);
-  PYBIND11_BIND_NDCUVEC(short, h);
-  PYBIND11_BIND_NDCUVEC(unsigned short, H);
-  PYBIND11_BIND_NDCUVEC(int, i);
-  PYBIND11_BIND_NDCUVEC(unsigned int, I);
-  PYBIND11_BIND_NDCUVEC(long long, q);
-  PYBIND11_BIND_NDCUVEC(unsigned long long, Q);
+  PYBIND11_BIND_NDxVEC(signed char, b);
+  PYBIND11_BIND_NDxVEC(unsigned char, B);
+  PYBIND11_BIND_NDxVEC(char, c);
+  PYBIND11_BIND_NDxVEC(short, h);
+  PYBIND11_BIND_NDxVEC(unsigned short, H);
+  PYBIND11_BIND_NDxVEC(int, i);
+  PYBIND11_BIND_NDxVEC(unsigned int, I);
+  PYBIND11_BIND_NDxVEC(long long, q);
+  PYBIND11_BIND_NDxVEC(unsigned long long, Q);
 #ifdef _CUVEC_HALF
-  PYBIND11_BIND_NDCUVEC(_CUVEC_HALF, e);
+  PYBIND11_BIND_NDxVEC(_CUVEC_HALF, e);
 #endif
-  PYBIND11_BIND_NDCUVEC(float, f);
-  PYBIND11_BIND_NDCUVEC(double, d);
+  PYBIND11_BIND_NDxVEC(float, f);
+  PYBIND11_BIND_NDxVEC(double, d);
   m.attr("__author__") = "Casper da Costa-Luis (https://github.com/casperdcl)";
   m.attr("__date__") = "2024";
   m.attr("__version__") = "2.0.0";


### PR DESCRIPTION
- add CPU-only vectors (fixes #36)
  + [x] `CVec`, `NDCVec`
  + [ ] pybind11
  + [ ] swig
  + [ ] cpython
